### PR TITLE
fix(js): only set value editor value if there is a value

### DIFF
--- a/django_json_editor_field/static/js/jsonwidget.js
+++ b/django_json_editor_field/static/js/jsonwidget.js
@@ -12,7 +12,9 @@ window.addEventListener('load', () => {
         input = element.getElementsByTagName('input')[0];
         editor = new JSONEditor(element, options);
         editor.on('ready', () => {
-            editor.setValue(JSON.parse(input.value));
+            if (JSON.parse(input.value)) {
+                editor.setValue(JSON.parse(input.value));
+            }
         });
         editor.on('change', () => {
             input = element.getElementsByTagName('input')[0];


### PR DESCRIPTION
This way the editor can start with a clean slate. Otherwise it always
starts with a list of one item;
