### PR TITLE
feat: loose the custom default settings

### DIFF
--- a/django_json_editor_field/static/js/jsonwidget.js
+++ b/django_json_editor_field/static/js/jsonwidget.js
@@ -1,12 +1,4 @@
 window.addEventListener('load', () => {
-    JSONEditor.defaults.options.theme = "bootstrap4";
-    JSONEditor.defaults.options.disable_collapse = true;
-    JSONEditor.defaults.options.disable_edit_json = true;
-    JSONEditor.defaults.options.disable_properties = true;
-    JSONEditor.defaults.options.disable_array_reorder = true;
-    JSONEditor.defaults.options.disable_array_delete_last_row = true;
-    JSONEditor.defaults.options.disable_array_delete_all_rows = true;
-    JSONEditor.defaults.options.prompt_before_delete = false;
     document.querySelectorAll(".jsoneditorwidget").forEach(function(element) {
         optionsContainer = element.nextElementSibling;
         options = JSON.parse(optionsContainer.textContent);


### PR DESCRIPTION
It is now possible to pass custom options to the widget, so we can drop
the defaults and users can simply set them as needed.
